### PR TITLE
Update curl link to correct 'raw' content link

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ action.
 
 # Installing
 
-    curl -O https://github.com/cogcmd/pagerduty/blob/master/config.yaml
+    curl -O https://raw.githubusercontent.com/cogcmd/pagerduty/master/config.yaml
     cogctl bundle install config.yaml
 
 # Building


### PR DESCRIPTION
You want the 'raw' link otherwise HTML is returned in the `curl` command and it makes for a no bueno day.
